### PR TITLE
Fix application failure caused by record instantiation in method check

### DIFF
--- a/lib/transitionable.rb
+++ b/lib/transitionable.rb
@@ -23,7 +23,6 @@ module Transitionable
       self.state_machines ||= {}
       self.state_machines[name] = { states: states.values, transitions: transitions }
       self.state_machines[name][:states].each do |this_state|
-        raise 'Method already defined' if self.new.respond_to? this_state
         define_method "#{this_state}?" do
           current_state_based_on(this_state) == this_state
         end

--- a/lib/transitionable.rb
+++ b/lib/transitionable.rb
@@ -23,7 +23,9 @@ module Transitionable
       self.state_machines ||= {}
       self.state_machines[name] = { states: states.values, transitions: transitions }
       self.state_machines[name][:states].each do |this_state|
-        define_method "#{this_state}?" do
+        method_name = "#{this_state}?".to_sym
+        raise 'Method already defined' if self.instance_methods(false).include?(method_name)
+        define_method method_name do
           current_state_based_on(this_state) == this_state
         end
       end

--- a/spec/single_machine_spec.rb
+++ b/spec/single_machine_spec.rb
@@ -46,6 +46,23 @@ RSpec.describe Transitionable do
       expect(event).not_to be_started
       expect(event).to be_completed
     end
+
+    it 'does not allow duplicate state' do
+      class DuplicateStateEvent
+        STATES_1 = {STAGED: 'staged'}
+        STATES_2 = {STAGED: 'staged'}
+        TRANSITIONS_1 = []
+        TRANSITIONS_2 = []
+        include Transitionable
+        attr_accessor :state_1, :state_2
+        transition :state_1, STATES_1, TRANSITIONS_1
+      end
+
+      expect{
+        DuplicateStateEvent.transition(:state_2, DuplicateStateEvent::STATES_2, DuplicateStateEvent::TRANSITIONS_2)
+      }.to raise_error(RuntimeError, 'Method already defined')
+      Object.send(:remove_const, :DuplicateStateEvent)
+    end
   end
 
   describe '#validate_transition' do

--- a/spec/single_machine_spec.rb
+++ b/spec/single_machine_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Transitionable do
     Object.send(:remove_const, Event) if Object.constants.include?(Event)
   end
 
-  describe 'helpers' do
+  describe '#transition' do
     let(:event) { Event.new }
     it 'defines helpers for all states' do
       event.some_state = Event::STATES[:STAGED]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "bundler/setup"
 require "transitionable"
+require 'pry'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
`self.new` causes issues in Rails because Rails loads all class before running migrations, at which point the table may not have been created.